### PR TITLE
Add TGT_CC and TGT_CXX

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -147,10 +147,20 @@ TARGET_DIR
 
    Default value: . (make's working directory; aka project root)
 
+TGT_CC
+------
+   Specifies the program to be used for compiling C sources. If this option is
+    not specified, CC is used.
+
 TGT_CFLAGS
 ----------
    Like SRC_CFLAGS, but applies to all sources belonging to the current target,
    not just sources in the current submakefile.
+
+TGT_CXX
+-------
+   Specifies the program to be used for compiling C++ sources. If this option
+    is not specified, CXX is used.
 
 TGT_CXXFLAGS
 ------------

--- a/Makefile
+++ b/Makefile
@@ -139,7 +139,9 @@ define INCLUDE_SUBMAKEFILE
     # Initialize all variables that can be defined by a makefile fragment, then
     # include the specified makefile fragment.
     TARGET        :=
+    TGT_CC        :=
     TGT_CFLAGS    :=
+    TGT_CXX       :=
     TGT_CXXFLAGS  :=
     TGT_DEFS      :=
     TGT_INCDIRS   :=
@@ -185,7 +187,9 @@ define INCLUDE_SUBMAKEFILE
         # makefile apply to this new target. Initialize the target's variables.
         TGT := $$(strip $${TARGET})
         ALL_TGTS += $${TGT}
+        $${TGT}_CC        := $${TGT_CC}
         $${TGT}_CFLAGS    := $${TGT_CFLAGS}
+        $${TGT}_CXX       := $${TGT_CXX}
         $${TGT}_CXXFLAGS  := $${TGT_CXXFLAGS}
         $${TGT}_DEFS      := $${TGT_DEFS}
         $${TGT}_DEPS      :=
@@ -247,6 +251,8 @@ define INCLUDE_SUBMAKEFILE
         # variables that were defined.
         $${TGT}_OBJS += $${OBJS}
         $${TGT}_DEPS += $${OBJS:%.o=%.P}
+        $${OBJS}: CC           := $$(if $${$${TGT}_CC},$${$${TGT}_CC},$${CC})
+        $${OBJS}: CXX          := $$(if $${$${TGT}_CXX},$${$${TGT}_CXX},$${CXX})
         $${OBJS}: SRC_CFLAGS   := $${$${TGT}_CFLAGS} $${SRC_CFLAGS}
         $${OBJS}: SRC_CXXFLAGS := $${$${TGT}_CXXFLAGS} $${SRC_CXXFLAGS}
         $${OBJS}: SRC_DEFS     := $$(addprefix -D,$${$${TGT}_DEFS} $${SRC_DEFS})


### PR DESCRIPTION
When building a project, some of which uses MPI, CC and CXX may need to
be overridden. We don't really want to use the MPI compiler for
everything, though, so being able to selectively specify a compiler is
helpful.
