### PR TITLE
Added special target EXECUTABLE_PER_SOURCE and colorization features

### DIFF
--- a/MANUAL
+++ b/MANUAL
@@ -137,6 +137,13 @@ TARGET
    SOURCES variable or any "TGT_*" variable specified in the child makefile
    applies to the target named "bar".
 
+   EXECUTABLE_PER_SOURCE can be used as a special target.  When this value is 
+   used as the target, each file in SOURCES is assumed to be an independent
+   the sole source for a single executable using the same build settings.  
+   Targets are automatically generated using the basename of each source file.  
+   This allows a series of these executables to be constructed using a single
+   .mk file.
+
 TARGET_DIR
 ----------
    Specifies the directory in which *all* final target files will be placed.


### PR DESCRIPTION
To satisfy the GPL I want to feed back updates I've made for use in my own projects in case you're interested.

I added a special target EXECUTABLE_PER_SOURCE in which case each source file is assumed compile to its own executable.  With many simple tools, this reduces the maintenance of having multiple .mk files and targets.  This required moving portions of INCLUDE_SUBMAKEFILE to their own functions (INIT_TGT and PREP_SOURCES).

I also added some colorized output, features though these aren't critical.  If you're actually interested in merging I can remove/isolate these changes.

Thanks for putting boilermake out in the open!
